### PR TITLE
docs: update changelog — fix v1.0.4→v1.0.6, add v1.0.7 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ binaries for every supported platform.
 
 ## What's new
 
-### v1.0.4
+### v1.0.7
 
-- `act update --version` pins a specific release during in-place upgrades
-- `act stats` estimates token savings for your workspace, based on benchmark medians
+- Added marketplace install support for OpenAI Codex
+- Added install support for opencode
+
+### v1.0.6
+
+- `act update` now supported — with version pinning (`--version`) and automatic background updates
+- `act stats` now estimates token savings based on benchmark medians
 
 Full release history in [CHANGELOG.md](https://github.com/act101-ai/act101/blob/main/CHANGELOG.md).
 


### PR DESCRIPTION
Syncs `README.md` with the private repo's `docs/public-README.md`.

- Fix version label: changelog entry was v1.0.4, should be v1.0.6
- Update v1.0.6 description: `act update` with version pinning and automatic background updates
- Add v1.0.7 release notes: Codex marketplace support, opencode install support